### PR TITLE
Initial implementation for serverwide basic HTTP authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,9 @@ if (EXAMPLES)
 
     if (CPP_BINDING)
         add_executable (helloworld examples/helloworld.cpp)
+        add_executable (basic_auth examples/basic_auth.cpp)
         target_link_libraries (helloworld  mongoose)
+        target_link_libraries (basic_auth  mongoose)
 
         add_executable (cpp examples/main.cpp)
         target_link_libraries (cpp  mongoose)

--- a/examples/basic_auth.cpp
+++ b/examples/basic_auth.cpp
@@ -1,0 +1,46 @@
+#ifdef _MSC_VER
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+#include <stdlib.h>
+#include <signal.h>
+#include <mongoose/Server.h>
+#include <mongoose/WebController.h>
+
+using namespace std;
+using namespace Mongoose;
+
+class MyController : public WebController
+{
+    public:
+        void hello(Request &request, StreamResponse &response)
+        {
+            response << "Hello " << htmlEntities(request.get("name", "... what's your name ?")) << endl;
+        }
+
+        void setup()
+        {
+            addRoute("GET", "/hello", MyController, hello);
+        }
+};
+
+
+int main()
+{
+    MyController myController;
+    Server server(8080);
+    server.setOption("basic_auth_username", "admin");
+    server.setOption("basic_auth_password", "admin");
+    server.registerController(&myController);
+
+    server.start();
+
+    while (1) {
+#ifdef WIN32
+		Sleep(10000);
+#else
+        sleep(10);
+#endif
+    }
+}


### PR DESCRIPTION
Implementing this as a server option in mongoose with support for 2
params: basic_auth_username, basic_auth_password

Usage:

    MyController myController;
    Server server(8080);
    server.setOption("basic_auth_username", "admin");
    server.setOption("basic_auth_password", "admin");
    server.registerController(&myController);
    server.start();

P.S My C is very rusty. You've been warned!